### PR TITLE
Quick fixes and docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,11 @@ Maintainer: The package maintainer <yourself@somewhere.net>
 Description: More about what it does (maybe more than one line)
     Use four spaces when indenting paragraphs within the Description.
 Depends: R (>= 4.0.0)
+Imports:
+    rlang,
+    glue,
+    httr,
+    curl
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Author: Who wrote it
 Maintainer: The package maintainer <yourself@somewhere.net>
 Description: More about what it does (maybe more than one line)
     Use four spaces when indenting paragraphs within the Description.
+Depends: R (>= 4.0.0)
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true

--- a/R/build_url.r
+++ b/R/build_url.r
@@ -1,10 +1,10 @@
-#' @title fill in
+#' @title Build URL Endpoints with Company Domain and API Version
 #'
 #' @description  fill in
 #'
-#' @param table_name tbd
 #' @param company_domain  tbd
-#' @param employee_id tbd
+#' @param api_version tbd
+#' @param base_url tbd
 #'
 #' @return text
 #'

--- a/R/get_company_file.R
+++ b/R/get_company_file.R
@@ -1,3 +1,14 @@
+#' @title Retrieve A Company File
+#'
+#' @description  fill in
+#'
+#' @param file_id  tbd
+#' @param ... tbd
+#'
+#' @return text
+#'
+#' @examples
+#'
 get_company_file <- function(file_id, ...){
   dots <- rlang::list2(...)
   #Default to directory if an individual employee is not specified

--- a/R/get_employee_file.R
+++ b/R/get_employee_file.R
@@ -4,7 +4,8 @@
 #'
 #' @param id employee ID. The special employee ID of zero (0) means to use the employee ID associated with the API key (if any).
 #' @param file_id  vector of values
-#' @param verbose Logical scalar. Should the function provide verbose messaging back on each step?
+#' @param verbose Logical scalar. Should the function provide verbose messaging back on each step? - (XL) Sounds good
+#' @param ... tbd
 #'
 #' @return response object
 #'
@@ -15,7 +16,7 @@
 #' @author Mark Druffel, \email{mdruffel@propellerpdx.com}
 
 
-get_employee_file <- function(id, file_id, ...){
+get_employee_file <- function(id, file_id, verbose, ...){
   dots <- rlang::list2(...)
   #Default to view if a file_id is not specified, this provides all files the employee has
   file_id <- rlang::maybe_missing(file_id, default = "view")

--- a/R/get_employee_file_meta.R
+++ b/R/get_employee_file_meta.R
@@ -1,3 +1,13 @@
+#' @title Get Employee File Meta Data
+#'
+#' @description  fill in
+#'
+#' @param ... tbd
+#'
+#' @return text
+#'
+#' @examples
+#'
 get_employee_file_meta <- function(...){
   dots <- rlang::list2(...)
 }

--- a/R/get_employees.r
+++ b/R/get_employees.r
@@ -5,6 +5,7 @@
 #' @param id employee ID. The special employee ID of zero (0) means to use the employee ID associated with the API key (if any).
 #' @param fields  vector of values
 #' @param verbose Logical scalar. Should the function provide verbose messaging back on each step?
+#' @param ... tbd
 #'
 #' @return response object
 #'
@@ -16,7 +17,7 @@
 #'
 #' @export
 
-get_employees <- function(id, fields, ...){
+get_employees <- function(id, fields, verbose, ...){
   dots <- rlang::list2(...)
   api <- "employees"
   #Default to directory if an individual employee is not specified

--- a/R/get_meta.R
+++ b/R/get_meta.R
@@ -4,6 +4,8 @@
 #' meta data API
 #'
 #' @param data fields, tables, lists, users, time_off/types, time_off/policies
+#' @param ... tbd
+#'
 #' @return tbl_df
 #'
 #' @examples

--- a/R/get_meta.R
+++ b/R/get_meta.R
@@ -16,8 +16,6 @@
 #'
 #' @references \url{https://documentation.bamboohr.com/reference#get-employee-table-row-1}
 #'
-#' @importFrom magrittr %>%
-#'
 #' @export
 #'
 

--- a/R/get_report.R
+++ b/R/get_report.R
@@ -3,6 +3,7 @@
 #' @description  Submits get requests to the Bamboo API
 #'
 #' @param id employee ID. The special employee ID of zero (0) means to use the employee ID associated with the API key (if any).
+#' @param format the format for query values appended to URL.
 #' @param fields  vector of values
 #' @param verbose Logical scalar. Should the function provide verbose messaging back on each step?
 #'
@@ -14,11 +15,11 @@
 #'
 #' @author Mark Druffel, \email{mdruffel@propellerpdx.com}
 
-get_report <- function(id, format, fd, ...){
+get_report <- function(id, format, fields, ...){
   dots <- rlang::list2(...)
   #Default to csv format is not specified - csv seems most likely
   format <- rlang::maybe_missing(format, default = "csv")
-  fd <- rlang::maybe_missing(fd, default = "yes")
+  fd <- rlang::maybe_missing(fields, default = "yes")
   query <- list(format = format, fd = fd)
   url <- build_url(company_domain = dots$company_domain,
                    api_version = dots$api_version,

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -17,8 +17,6 @@
 #'
 #' @references \url{https://documentation.bamboohr.com/reference#get-employee-table-row-1}
 #'
-#' @importFrom magrittr %>%
-#'
 #' @export
 #'
 
@@ -34,7 +32,7 @@ get_table <- function(table, id, since, ...){
   url <- build_url(company_domain = dots$company_domain,
                    api_version = dots$api_version,
                    base_url = dots$base_url)
-  url <- glue::glue("{url}/employees/{id}/tables/{table}") %>%
+  url <- glue::glue("{url}/employees/{id}/tables/{table}") |>
     httr::modify_url(query = query)
   response <- get_request(url)
 }

--- a/R/get_timeoff.R
+++ b/R/get_timeoff.R
@@ -17,8 +17,6 @@
 #'
 #' @references \url{https://documentation.bamboohr.com/reference#get-employee-table-row-1}
 #'
-#' @importFrom magrittr %>%
-#'
 #' @export
 #'
 
@@ -34,7 +32,7 @@ get_timeoff <- function(id, action, employee_id, start, end, type, status, ...){
   url <- build_url(company_domain = dots$company_domain,
                    api_version = dots$api_version,
                    base_url = dots$base_url)
-  url <- glue::glue("{url}/employees/{id}/tables/{table}") %>%
+  url <- glue::glue("{url}/employees/{id}/tables/{table}") |>
     httr::modify_url(query = query)
   response <- get_request(url)
 }

--- a/R/scratch.R
+++ b/R/scratch.R
@@ -1,3 +1,5 @@
+library(magrittr)
+
 fields <- get_meta(data = "fields") %>%
   httr::content(., as='text', type='json', encoding='UTF-8') %>%
   jsonlite::fromJSON(., simplifyDataFrame=FALSE) %>%


### PR DESCRIPTION
Nothing major is added, just fixed a few inconsistency in documentation.

The only addition is requiring R version >= 4.0 which enables the pipe operator `|>` and removes dependency of `magrittr` package. Hopefully nothing controversial.